### PR TITLE
FIP 12, timeouts

### DIFF
--- a/_example/transfer-long-timeout.go
+++ b/_example/transfer-long-timeout.go
@@ -1,0 +1,50 @@
+package main
+
+// example of transferring FIO tokens, AND overriding the default timeout from 30 seconds to 1 hour.
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/fioprotocol/fio-go"
+	"log"
+	"time"
+)
+
+func main() {
+	const (
+		url = `https://testnet.fioprotocol.io`
+		wif = `5JP1fUXwPxuKuNryh5BEsFhZqnh59yVtpHqHxMMTmtjcni48bqC`
+
+		to = `FIO6G9pXXM92Gy5eMwNquGULoCj3ZStwPLPdEb9mVXyEHqWN7HSuA`
+	)
+
+	fatal := func(e error) {
+		if e != nil {
+			log.Fatal(e)
+		}
+	}
+
+	// Note that txOpts are needed.
+	account, api, txOpts, err := fio.NewWifConnect(wif, url)
+	fatal(err)
+
+	// The timeout is part of the transaction, so instead of using SignPushActions, create an un-packed transaction
+	tx := fio.NewTransaction(
+		[]*fio.Action{
+			fio.NewTransferTokensPubKey(account.Actor, to, fio.Tokens(1.0)),
+		},
+		txOpts,
+	)
+
+	// override the expiration with the longest allowed timeout, FC will reject anything more than 3600 seconds
+	tx.SetExpiration(time.Hour)
+
+	// send ᵮ1.00
+	// Now instead of SignPushActions, it is sent with SignPushTransaction
+	resp, err := api.SignPushTransaction(tx, txOpts.ChainID, fio.CompressionNone)
+	fatal(err)
+
+	j, err := json.MarshalIndent(resp, "", "  ")
+	fatal(err)
+	fmt.Println(string(j))
+}

--- a/chain.go
+++ b/chain.go
@@ -418,7 +418,8 @@ type AllowedAction struct {
 	BlockTimeStamp eos.BlockTimestamp `json:"block_time_stamp"` // unixtime value
 }
 
-// AllowedActionResp holds the response from a get_actions API call, adds 'Allowed' prefix to avoid endpoint name ambiguity
+// AllowedActionResp holds the response from a get_actions API call, adds 'Allowed' prefix to avoid a conflict with
+// eos libraries caused by an unfortunate choice in endpoint naming
 type AllowedActionsResp struct {
 	Actions []AllowedAction `json:"actions"`
 	More    uint32          `json:"more"`
@@ -434,11 +435,6 @@ func (api *API) GetAllowedActions(offset uint32, limit uint32) (allowed *Allowed
 	allowed = &AllowedActionsResp{}
 	err = api.call("chain", "get_actions", allowedActionsReq{Limit: limit, Offset: offset}, allowed)
 	return
-}
-
-// GetActions is an alias for GetAllowedActions
-func (api *API) GetActions(offset uint32, limit uint32) (allowed *AllowedActionsResp, err error) {
-	return api.GetAllowedActions(offset, limit)
 }
 
 // BlockHeaderState holds information about reversible blocks.

--- a/chain.go
+++ b/chain.go
@@ -399,7 +399,7 @@ type RemoveAction struct {
 	Actor  eos.AccountName `json:"actor"`
 }
 
-func NewRemoveAction(action eos.ActionName, actor eos.AccountName) (action *Action) {
+func NewRemoveAction(action eos.ActionName, actor eos.AccountName) *Action {
 	return NewAction("eosio", "remaction", actor, RemoveAction{
 		Action: action,
 		Actor:  actor,
@@ -407,7 +407,7 @@ func NewRemoveAction(action eos.ActionName, actor eos.AccountName) (action *Acti
 }
 
 // NewRemAction is an alias for NewRemoveAction
-func NewRemAction(action eos.ActionName, actor eos.AccountName) (action *Action) {
+func NewRemAction(action eos.ActionName, actor eos.AccountName) *Action {
 	return NewRemoveAction(action, actor)
 }
 
@@ -424,21 +424,21 @@ type AllowedActionsResp struct {
 	More    uint32          `json:"more"`
 }
 
-type AllowedActionsReq struct {
+type allowedActionsReq struct {
 	Limit  uint32 `json:"limit"`
 	Offset uint32 `json:"offset"`
 }
 
 // GetAllowedActions fetches the list of allowed actions from get_actions
-func (api *API) GetAllowedActions(getActionReq AllowedActionsReq) (allowed *AllowedActionsResp, err error) {
+func (api *API) GetAllowedActions(offset uint32, limit uint32) (allowed *AllowedActionsResp, err error) {
 	allowed = &AllowedActionsResp{}
-	err = api.call("chain", "get_actions", getActionReq, allowed)
+	err = api.call("chain", "get_actions", allowedActionsReq{Limit: limit, Offset: offset}, allowed)
 	return
 }
 
 // GetActions is an alias for GetAllowedActions
-func (api *API) GetActions(getActionReq AllowedActionsReq) (allowed *AllowedActionsResp, err error) {
-	return api.GetAllowedActions(getActionReq)
+func (api *API) GetActions(offset uint32, limit uint32) (allowed *AllowedActionsResp, err error) {
+	return api.GetAllowedActions(offset, limit)
 }
 
 // BlockHeaderState holds information about reversible blocks.

--- a/eos/transaction.go
+++ b/eos/transaction.go
@@ -123,7 +123,7 @@ func (tx *Transaction) Fill(headBlockID Checksum256, delaySecs, maxNetUsageWords
 	tx.MaxCPUUsageMS = maxCPUUsageMS
 	tx.DelaySec = Varuint32(delaySecs)
 
-	tx.SetExpiration(30 * time.Second)
+	tx.SetExpiration(3 * time.Minute)
 }
 
 func (tx *Transaction) setRefBlock(blockID []byte) {


### PR DESCRIPTION
- Adds types and functions for FIP12
- New example for overriding default tx timeout
- Bump tx timeout from 30 seconds to 3 minutes.

Resolves #21 