### PR TITLE
Hotfix/v1.0.1 2

### DIFF
--- a/eos/api.go
+++ b/eos/api.go
@@ -364,6 +364,13 @@ func (api *API) SignTransaction(tx *Transaction, chainID Checksum256, compressio
 		requiredKeys = resp.RequiredKeys
 	}
 
+	// FIO specific safety check for fee value over/underflow
+	for i := range tx.Actions {
+		if err := checkFeeRange(tx.Actions[i]); err != nil {
+			return nil, nil, err
+		}
+	}
+
 	signedTx, err := api.Signer.Sign(stx, chainID, requiredKeys...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("signing through wallet: %s", err)

--- a/eos/api.go
+++ b/eos/api.go
@@ -366,7 +366,7 @@ func (api *API) SignTransaction(tx *Transaction, chainID Checksum256, compressio
 
 	// FIO specific safety check for fee value over/underflow
 	for i := range tx.Actions {
-		if err := checkFeeRange(tx.Actions[i]); err != nil {
+		if err := CheckFioFeeRange(tx.Actions[i]); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/eos/fio-fees.go
+++ b/eos/fio-fees.go
@@ -37,7 +37,7 @@ func CheckFioFeeRange(action *Action) error {
 	case reflect.Uint64:
 		return CheckUnderOver(maxFee.Uint())
 	case reflect.Int64:
-		return CheckUnderOver(maxFee.Uint())
+		return CheckUnderOver(maxFee.Int())
 	case reflect.Float32, reflect.Float64:
 		return errors.New("CheckFioFeeRange: cannot be a float")
 	case reflect.String:

--- a/eos/fio-fees.go
+++ b/eos/fio-fees.go
@@ -1,0 +1,71 @@
+package eos
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"reflect"
+	"strconv"
+)
+
+/*
+These are FIO-specific modifications to eos-go
+ */
+
+// checkFeeRange is a safety mechanism to check if an action has a fee and prevents under/over flows.
+// Not all fees are consistently one type, some are uint64 and some are int64.
+// All of the structures in fio-go treat them as a uint64 for consistency.
+func checkFeeRange(action *Action) error {
+	switch true {
+	case action == nil:
+		return errors.New("validateFee: invalid, Action is nil")
+	case action.HexData != nil && action.Data == nil:
+		// only check if an embedded struct exists
+		return nil
+	case action.Data == nil:
+		return errors.New("checkFeeRange: invalid, Data is nil")
+	case reflect.TypeOf(action.ActionData.Data).Kind() != reflect.Struct:
+		return errors.New("checkFeeRange: invalid, Data is not a struct")
+	}
+
+	maxFee := reflect.ValueOf(action.ActionData.Data).FieldByName("MaxFee")
+	if !maxFee.IsValid() {
+		// MaxFee doesn't exist, all clear
+		return nil
+	}
+	switch maxFee.Kind() {
+	case reflect.Uint64:
+		return checkUnderOver(maxFee.Uint())
+	case reflect.Int64:
+		return checkUnderOver(maxFee.Uint())
+	case reflect.Float32, reflect.Float64:
+		return errors.New("checkFeeRange cannot be a float")
+	case reflect.String:
+		i, err := strconv.ParseInt(maxFee.String(), 10, 64)
+		if err != nil {
+			return err
+		}
+		return checkUnderOver(i)
+	}
+
+	return errors.New(fmt.Sprintf("checkFeeRange: cannot validate type (%s) for MaxFee, allowed types are uint64, int64, and string", maxFee.Kind().String()))
+}
+
+// checkUnderOver throws an error if an int64 < 0 or uint64 > 9,223,372,036,854,775,807 to prevent sending out of range
+// values to nodeos which will allow over/under flows.
+func checkUnderOver(v interface{}) error {
+	switch v.(type) {
+	case uint64:
+		if v.(uint64) > math.MaxInt64 {
+			return errors.New("checkUnderOver: fee could overflow int64")
+		}
+		return nil
+	case int64:
+		if v.(int64) < 0 {
+			return errors.New("checkUnderOver: fee could underflow uint64")
+		}
+		return nil
+	}
+	return errors.New("checkUnderOver: not an int64 or uint64")
+}
+

--- a/fee.go
+++ b/fee.go
@@ -321,7 +321,7 @@ func NewSetFeeMult(multiplier float64, actor eos.AccountName) *Action {
 type ComputeFees struct{}
 
 func NewComputeFees(actor eos.AccountName) *Action {
-	return NewAction("fio.fee", "updatefees", actor, ComputeFees{})
+	return NewAction("fio.fee", "computefees", actor, ComputeFees{})
 }
 
 // FioFee (table query response) holds the details of an action's fee stored in the fio.fee fiofees table.

--- a/fee.go
+++ b/fee.go
@@ -237,15 +237,17 @@ func MaxFeesJson() []byte {
 	return j
 }
 
+// CreateFee is a privileged action that adds a new fee record in the fiofees table
 type CreateFee struct {
 	EndPoint  string `json:"end_point"`
-	Type      uint64 `json:"type"`
-	SufAmount uint64 `json:"suf_amount"`
+	Type      int64  `json:"type"`
+	SufAmount int64  `json:"suf_amount"`
 }
 
+// FeeValue is used by block producers to vote on the base cost (before multiplier) for a fee
 type FeeValue struct {
 	EndPoint string `json:"end_point"`
-	Value    uint64 `json:"value"`
+	Value    int64  `json:"value"`
 }
 
 // GetMaxFees gets the current max fees as a slice of FeeValue
@@ -256,7 +258,7 @@ func GetMaxFees() []FeeValue {
 	for k, v := range maxFees {
 		fees[i] = FeeValue{
 			EndPoint: k,
-			Value:    uint64(v * 1_000_000_000),
+			Value:    int64(v * 1_000_000_000),
 		}
 		i += 1
 	}
@@ -264,7 +266,7 @@ func GetMaxFees() []FeeValue {
 	return fees
 }
 
-// NewSetFeeVote is used by block producers to adjust the fee for an action, it is possible that not all fees will
+// SetFeeVote is used by block producers to adjust the fee for an action, it is possible that not all fees will
 // fit into a single transaction and may require multiple calls.
 type SetFeeVote struct {
 	FeeRatios []*FeeValue     `json:"fee_ratios"`
@@ -284,12 +286,12 @@ func NewSetFeeVote(ratios []*FeeValue, actor eos.AccountName) *Action {
 // BundleVote is used by block producers to vote for the number of free transactions included when registering or
 // renewing a FIO address
 type BundleVote struct {
-	BundledTransactions uint64 `json:"bundled_transactions"`
+	BundledTransactions int64  `json:"bundled_transactions"`
 	Actor               string `json:"actor"`
 	MaxFee              uint64 `json:"max_fee"`
 }
 
-func NewBundleVote(transactions uint64, actor eos.AccountName) *Action {
+func NewBundleVote(transactions int64, actor eos.AccountName) *Action {
 	return NewAction("fio.fee", "bundlevote", actor,
 		BundleVote{
 			BundledTransactions: transactions,
@@ -331,6 +333,7 @@ type FioFee struct {
 	EndPointHash eos.Uint128 `json:"end_point_hash"`
 	Type         uint64      `json:"type"`
 	SufAmount    uint64      `json:"suf_amount"`
+	VotesPending eos.Bool    `json:"votes_pending"`
 }
 
 // FeeVoter (table query response) holds information about the block producer performing a multiplier vote
@@ -342,12 +345,27 @@ type FeeVoter struct {
 }
 
 // FeeVote (table query response) holds fee vote information from the fio.fee feevotes table
+//
+// Deprecated: replaced by FeeVote2
 type FeeVote struct {
 	Id                uint64          `json:"id"`
 	BlockProducerName eos.AccountName `json:"block_producer_name"`
 	EndPoint          string          `json:"end_point"`
-	EndPointHash      uint64          `json:"end_point_hash"`
+	EndPointHash      eos.Uint128     `json:"end_point_hash"`
 	SufAmount         uint64          `json:"suf_amount"`
+	LastVoteTimestamp uint64          `json:"lastvotetimestamp"`
+}
+
+type FeeValueTs struct {
+	FeeValue
+	TimeStame uint64 `json:"time_stame"`
+}
+
+// FeeVote2 (query response) is the new voting table format
+type FeeVote2 struct {
+	Id                uint64          `json:"id"`
+	BlockProducerName eos.AccountName `json:"block_producer_name"`
+	FeeVotes          []FeeValueTs    `json:"fee_votes"`
 	LastVoteTimestamp uint64          `json:"lastvotetimestamp"`
 }
 
@@ -355,6 +373,6 @@ type FeeVote struct {
 // or renewed addresses as stored in the fio.fee bundlevotes table.
 type BundleVoter struct {
 	BlockProducerName eos.AccountName `json:"block_producer_name"`
-	BundleVoteNumber  uint64          `json:"bundlevotenumber"`
+	BundleVoteNumber  int64           `json:"bundlevotenumber"`
 	LastVoteTimestamp uint64          `json:"lastvotetimestamp"`
 }

--- a/fee_test.go
+++ b/fee_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/fioprotocol/fio-go/eos"
+	"math"
 	"strconv"
 	"testing"
 )
@@ -67,6 +68,67 @@ func Test_NewSetFeeVote(t *testing.T) {
 		t.Error(err)
 		fmt.Println(resp)
 	}
+}
+
+func Test_FeeOverUnderflow(t *testing.T) {
+	account, api, opts, err := newApi()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	// Baseline
+	goodFee := NewAction("fio.address", "rmalladdr", account.Actor, RemoveAllAddrReq{
+		FioAddress: "test@123",
+		MaxFee: uint64(math.MaxInt64),
+		Actor: account.Actor,
+		Tpid: "123@test",
+	})
+	_, _, err = api.SignTransaction(NewTransaction([]*Action{goodFee}, opts), opts.ChainID, CompressionNone)
+	if err != nil {
+		t.Error("legit fee blocked when signing transaction")
+	}
+
+	// negative int into uint
+	// it's actually a little difficult to trick the compiler into allowing this to be triggered, so very low risk.
+	var temp interface{}
+	temp = int64(-1)
+	underFlowFee := NewAction("fio.address", "rmalladdr", account.Actor, RemoveAllAddrReq{
+		FioAddress: "test@123",
+		// use reflection to forcefully cast, results in MaxFee:18446744073709551615
+		MaxFee: uint64(temp.(int64)), // #nosec
+		Actor: account.Actor,
+		Tpid: "123@test",
+	})
+	_, _, err = api.SignTransaction(NewTransaction([]*Action{underFlowFee}, opts), opts.ChainID, CompressionNone)
+	if err == nil {
+		t.Error("potential uint underflow not blocked when signing transaction")
+	}
+
+	// uint too large for int
+	// this, however, could happen easily.
+	overFlowFee := NewAction("fio.address", "rmalladdr", account.Actor, RemoveAllAddrReq{
+		FioAddress: "test@123",
+		MaxFee: uint64(math.MaxInt64 + 1), // #nosec
+		Actor: account.Actor,
+		Tpid: "123@test",
+	})
+	_, _, err = api.SignTransaction(NewTransaction([]*Action{overFlowFee}, opts), opts.ChainID, CompressionNone)
+	if err == nil {
+		t.Error("potential int overflow not blocked when signing transaction")
+	}
+
+	// negative int into int
+	// most likely scenario ... could happen if using ABI to encode, but we'll just create a fake action to test
+	type fakeAction struct {
+		MaxFee int64 `json:"max_fee"`
+	}
+	underFlowAbi := NewAction("fake", "action", account.Actor, fakeAction{MaxFee: -1})
+	_, _, err = api.SignTransaction(NewTransaction([]*Action{underFlowAbi}, opts), opts.ChainID, CompressionNone)
+	if err == nil {
+		t.Error("potential uint underflow not blocked when signing transaction")
+	}
+
 }
 
 func Test_NewSubmitMultiplier(t *testing.T) {


### PR DESCRIPTION
**Warning: breaking changes for fees.** Most of these are new, so should have minimal impact, but several signed integers in fees.go were incorrectly set as uint64 instead of int64.

* Add checks for integer conversion before signing a transaction, some actions want unsigned, but others want signed for the MaxFee field. Will continue to use uint64 on *all* actions for consistency and refuse to sign in the case of an overflow.
* Fix many fields in fee.go labeled as uint instead of int.
* Fix wrong action on compute_fees call
* more tests
