### PR TITLE
Release v1.0.3

### DIFF
--- a/eos/fio-fees.go
+++ b/eos/fio-fees.go
@@ -25,7 +25,7 @@ func CheckFioFeeRange(action *Action) error {
 	case action.Data == nil:
 		return errors.New("CheckFioFeeRange: invalid, Data is nil")
 	case reflect.TypeOf(action.ActionData.Data).Kind() != reflect.Struct:
-		return errors.New("CheckFioFeeRange: invalid, Data is not a struct")
+		return nil
 	}
 
 	maxFee := reflect.ValueOf(action.ActionData.Data).FieldByName("MaxFee")

--- a/locked-tokens.go
+++ b/locked-tokens.go
@@ -33,7 +33,7 @@ const (
 
 // GenesisLockedTokens holds information about tokens that were locked at chain genesis.
 type GenesisLockedTokens struct {
-	Name                  eos.AccountName `json:"name"`
+	Name                  eos.AccountName `json:"owner"`
 	TotalGrantAmount      uint64          `json:"total_grant_amount"`
 	UnlockedPeriodCount   uint32          `json:"unlocked_period_count"`
 	GrantType             uint32          `json:"grant_type"`

--- a/locked-tokens.go
+++ b/locked-tokens.go
@@ -17,9 +17,9 @@ import (
 
 // set as variables to allow override on development nets
 var (
-	LockedInitial              = 90    // initial days before first unlock period
+	LockedInitial              = 90 * 24 * 60    // initial minutes before first unlock period
 	LockedInitialPct   float64 = 0.06  // percentage unlocked after first period
-	LockedIncrement            = 180   // each additional unlock period, 2nd unlock = LockedInitial + LockedIncrement, 3rd = LockedInitial + (2 * LockedIncrement), etc
+	LockedIncrement            = 180 * 24 * 60   // each additional unlock period, 2nd unlock = LockedInitial + LockedIncrement, 3rd = LockedInitial + (2 * LockedIncrement), etc
 	LockedIncrementPct float64 = 0.188 // percent unlocked each additional period: 1st = 6%, 2nd = 24.8% etc.
 	LockedPeriods              = 6     // number of unlock periods
 )
@@ -102,16 +102,16 @@ func (g *GenesisLockedTokens) ActualRemaining() (tokens uint64, err error) {
 		fallthrough
 
 	case LockedFounder, LockedPresale:
-		days := int(time.Now().Sub(lockStart).Hours()) / 24
+		minutes := int(time.Now().Sub(lockStart).Minutes())
 		// have not passed first period
-		if days < LockedInitial {
+		if minutes < LockedInitial {
 			return g.RemainingLockedAmount, nil
 		}
 		// first unlock passed
 		pct := LockedInitialPct
 		// add percentage for each additional
 		for i := 1; i <= LockedPeriods; i++ {
-			if days >= (i*LockedIncrement)+LockedInitial {
+			if minutes >= (i*LockedIncrement)+LockedInitial {
 				pct += LockedIncrementPct
 			} else {
 				break

--- a/locked-tokens.go
+++ b/locked-tokens.go
@@ -104,14 +104,14 @@ func (g *GenesisLockedTokens) ActualRemaining() (tokens uint64, err error) {
 	case LockedFounder, LockedPresale:
 		days := int(time.Now().Sub(lockStart).Hours()) / 24
 		// have not passed first period
-		if days <= LockedInitial {
+		if days < LockedInitial {
 			return g.RemainingLockedAmount, nil
 		}
 		// first unlock passed
 		pct := LockedInitialPct
 		// add percentage for each additional
 		for i := 1; i <= LockedPeriods; i++ {
-			if days > (i*LockedIncrement)+LockedInitial {
+			if days >= (i*LockedIncrement)+LockedInitial {
 				pct += LockedIncrementPct
 			} else {
 				break

--- a/locked-tokens.go
+++ b/locked-tokens.go
@@ -104,7 +104,7 @@ func (g *GenesisLockedTokens) ActualRemaining() (tokens uint64, err error) {
 	case LockedFounder, LockedPresale:
 		days := int(time.Now().Sub(lockStart).Hours()) / 24
 		// have not passed first period
-		if days < LockedInitial {
+		if days <= LockedInitial {
 			return g.RemainingLockedAmount, nil
 		}
 		// first unlock passed

--- a/producer.go
+++ b/producer.go
@@ -341,7 +341,10 @@ func (api *API) getBpJson(producer eos.AccountName, allowIp bool) (*BpJson, erro
 	}
 
 	var regJson, chainsJson, thisChainJson string
-	info, _ := api.GetInfo()
+	info, err := api.GetInfo()
+	if err != nil {
+		return nil, err
+	}
 
 	server := strings.TrimRight(u.String(), "/")
 	thisChainJson = server + "/bp." + info.ChainID.String() + ".json"


### PR DESCRIPTION
Primarily bug fixes for locked tokens:

- fixes off-by-one error on calculating when unlock periods happen
- changes lock time units to be more granular to facilitate tests
- prevents a condition where getting data from the `locktockens` table results in tens of thousands of API calls

- Fixes an error in the fee value safety checks that would cause an error on transactions with a fee but a nil body. 
- Fixes several issues with parsing BP.json, and adds support for the chains.json handling.