### PR TITLE
Maintenance release v1.0.4

### DIFF
--- a/fee.go
+++ b/fee.go
@@ -360,15 +360,16 @@ type FeeVote struct {
 }
 
 type FeeValueTs struct {
-	FeeValue
-	TimeStame uint64 `json:"time_stame"`
+	EndPoint string `json:"end_point"`
+	Value    int64  `json:"value"`
+	TimeStamp uint64 `json:"timestamp"`
 }
 
 // FeeVote2 (query response) is the new voting table format
 type FeeVote2 struct {
 	Id                uint64          `json:"id"`
 	BlockProducerName eos.AccountName `json:"block_producer_name"`
-	FeeVotes          []FeeValueTs    `json:"fee_votes"`
+	FeeVotes          []FeeValueTs    `json:"feevotes"`
 	LastVoteTimestamp uint64          `json:"lastvotetimestamp"`
 }
 

--- a/go.sum
+++ b/go.sum
@@ -80,7 +80,6 @@ github.com/mattn/go-ieproxy v0.0.0-20190610004146-91bb50d98149/go.mod h1:31jz6HN
 github.com/mattn/go-ieproxy v0.0.0-20190702010315-6dee0af9227d/go.mod h1:31jz6HNzdxOmlERGGEc4v/dMssOfmp2p5bT/okiKFFc=
 github.com/mattn/go-isatty v0.0.5-0.20180830101745-3fb116b82035/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
-github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mr-tron/base58 v1.2.0 h1:T/HDJBh4ZCPbU39/+c3rRvE0uKBQlU27+QI8LJ4t64o=

--- a/locked-tokens.go
+++ b/locked-tokens.go
@@ -17,11 +17,11 @@ import (
 
 // set as variables to allow override on development nets
 var (
-	LockedInitial              = 90 * 24 * 60    // initial minutes before first unlock period
-	LockedInitialPct   float64 = 0.06  // percentage unlocked after first period
-	LockedIncrement            = 180 * 24 * 60   // each additional unlock period, 2nd unlock = LockedInitial + LockedIncrement, 3rd = LockedInitial + (2 * LockedIncrement), etc
-	LockedIncrementPct float64 = 0.188 // percent unlocked each additional period: 1st = 6%, 2nd = 24.8% etc.
-	LockedPeriods              = 6     // number of unlock periods
+	LockedInitial              = 90 * 24 * 60  // initial minutes before first unlock period
+	LockedInitialPct   float64 = 0.06          // percentage unlocked after first period
+	LockedIncrement            = 180 * 24 * 60 // each additional unlock period, 2nd unlock = LockedInitial + LockedIncrement, 3rd = LockedInitial + (2 * LockedIncrement), etc
+	LockedIncrementPct float64 = 0.188         // percent unlocked each additional period: 1st = 6%, 2nd = 24.8% etc.
+	LockedPeriods              = 6             // number of unlock periods
 )
 
 const (
@@ -359,7 +359,7 @@ func (api *API) GetTotalLockTokens() (uint64, error) {
 			}
 		}
 		if gtr.More {
-			lower = strconv.FormatUint(uint64(ltr[len(ltr) - 1].Id), 10)
+			lower = strconv.FormatUint(uint64(ltr[len(ltr)-1].Id), 10)
 		}
 		more = gtr.More
 	}

--- a/locked-tokens.go
+++ b/locked-tokens.go
@@ -390,15 +390,7 @@ func (api *API) GetCirculatingSupply() (circulating uint64, minted uint64, locke
 	if err != nil {
 		return
 	}
-	userLock, err = api.GetTotalLockTokens()
-	if err != nil {
-		return
-	}
-	rewLock, err = api.GetLockedBpRewards()
-	if err != nil {
-		return
-	}
-	return supply - genesis - userLock - rewLock, supply, genesis + userLock + rewLock, nil
+	return supply - genesis, supply, genesis, nil
 }
 
 // GetLockedBpRewards gets the unpaid rewards for block producers: Fees collected for FIO Address/Domain

--- a/locked-tokens.go
+++ b/locked-tokens.go
@@ -374,7 +374,7 @@ func (api *API) GetTotalLockTokens() (uint64, error) {
 // this is a very busy call, requiring multiple requests to calculate the result, and it is recommended to cache the
 // output if needed frequently.
 func (api *API) GetCirculatingSupply() (circulating uint64, minted uint64, locked uint64, err error) {
-	var supply, genesis, userLock, rewLock uint64
+	var supply, genesis uint64
 	gcr := &eos.GetCurrencyStatsResp{}
 	gcr, err = api.GetCurrencyStats("fio.token", "FIO")
 	if err != nil {


### PR DESCRIPTION
* updates circulating supply calculations. Locked BP rewards, and user-locked tokens will be treated as circulating.
* Fixes some issues with fee structs